### PR TITLE
Add new iterative solvers and remove dependency on UMFPack

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,13 +11,14 @@ target_link_libraries(PeriodicTest
   PRIVATE MFEMMGIS)
   add_dependencies(check PeriodicTest)
 
-function(add_periodic_test ncase)
-  set(test "PeriodicTest-${ncase}")
+function(add_periodic_test ncase nsolver)
+  set(test "PeriodicTest-${ncase}-${nsolver}")
   add_test(NAME ${test}
    COMMAND PeriodicTest 
    "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube_2mat_per.mesh"
    "--library" "$<TARGET_FILE:BehaviourTest>"
-   "--test-case" "${ncase}")
+   "--test-case" "${ncase}"
+   "--linearsolver" "${nsolver}")
   if((CMAKE_HOST_WIN32) AND (NOT MSYS))
     set_property(TEST ${test}
       PROPERTY DEPENDS BehaviourTest
@@ -28,12 +29,11 @@ function(add_periodic_test ncase)
   endif((CMAKE_HOST_WIN32) AND (NOT MSYS))
 endfunction(add_periodic_test)
 
-add_periodic_test(0)
-add_periodic_test(1)
-add_periodic_test(2)
-add_periodic_test(3)
-add_periodic_test(4)
-add_periodic_test(5)
+foreach(ncase RANGE 0 5)
+  foreach(nsolver RANGE 0 1)
+    add_periodic_test(${ncase} ${nsolver})
+  endforeach(nsolver)
+endforeach(ncase)
 
 add_executable(UnilateralTensileTest
   EXCLUDE_FROM_ALL

--- a/tests/PeriodicTest.cxx
+++ b/tests/PeriodicTest.cxx
@@ -127,6 +127,7 @@ int main(const int argc, char** const argv) {
   const char* library = nullptr;
   auto order = 1;
   auto tcase = 0;
+  auto linearsolver = 0;
   // options treatment
   mfem::OptionsParser args(argc, argv);
   args.AddOption(&mesh_file, "-m", "--mesh", "Mesh file to use.");
@@ -136,6 +137,8 @@ int main(const int argc, char** const argv) {
   args.AddOption(&tcase, "-t", "--test-case",
                  "identifier of the case : Exx->0, Eyy->1, Ezz->2, Exy->3, "
                  "Exz->4, Eyz->5");
+  args.AddOption(&linearsolver, "-ls", "--linearsolver",
+                 "identifier of the linear solver: 0 -> GMRES, 1 -> CG, 2 -> UMFPack");
   args.Parse();
   if ((!args.Good()) || (mesh_file == nullptr)) {
     args.PrintUsage(std::cout);
@@ -199,7 +202,7 @@ int main(const int argc, char** const argv) {
   }
   problem.SetEssentialTrueDofs(ess_tdof_list);
   // solving the problem
-  std::shared_ptr<mfem::Solver> lsolver = solver_list[1]();
+  std::shared_ptr<mfem::Solver> lsolver = solver_list[linearsolver]();
 
   auto& solver = problem.getSolver();
   solver.iterative_mode = true;


### PR DESCRIPTION
In order to lay the ground for parallel computing, this pull request introduces the access to other iterative solvers in one of the test case.
The requirement for UMFPack solver should disappear.