### PR TITLE
Still some warnings compiling with g++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
   SETUP_TARGET_FOR_COVERAGE(coverage ctest coverage)
 endif(CMAKE_BUILD_TYPE STREQUAL "Coverage")
 
+if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+  string(APPEND CMAKE_CXX_FLAGS " -Wno-ctor-dtor-privacy -Wno-float-equal") 
+endif(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+
 # MFEM
 find_package(MFEM REQUIRED)
 


### PR DESCRIPTION
I have still some problems to get rid of the warnings during comilation with g++8.1, even with your recent changes with tfel@master. This pull request solves the following problems:

1) during make
```
[95%] Building CXX object src/CMakeFiles/MFEMMGIS.dir/OrthotropicPlaneStressStandardSmallStrainMechanicsBehaviourIntegrator.cxx
.o
In file included from /home/glatu/mfem-mgis/include/MFEMMGIS/RotationMatrix.hxx:13,
                 from /home/glatu/mfem-mgis/include/MFEMMGIS/BehaviourIntegrator.hxx:15,
                 from /home/glatu/mfem-mgis/src/BehaviourIntegrator.cxx:8:
/trinity/shared/apps/custom/x86_64/gcc-8.1.0/include/c++/8.1.0/variant:463:7: note: « std::__detail::__variant::_Copy_ctor_base
<<anonyme>, _Types>::_Copy_ctor_base(const std::__detail::__variant::_Copy_ctor_base<<anonyme>, _Types>&) » est public mais req
uiert un objet « struct std::__detail::__variant::_Copy_ctor_base<<anonyme>, _Types> » existant
       _Copy_ctor_base(const _Copy_ctor_base& __rhs)
       ^~~~~~~~~~~~~~~
/trinity/shared/apps/custom/x86_64/gcc-8.1.0/include/c++/8.1.0/variant:497:7: note: « std::__detail::__variant::_Move_ctor_base
<<anonyme>, _Types>::_Move_ctor_base(std::__detail::__variant::_Move_ctor_base<<anonyme>, _Types>&&) » est public mais requiert
 un objet « struct std::__detail::__variant::_Move_ctor_base<<anonyme>, _Types> » existant
       _Move_ctor_base(_Move_ctor_base&& __rhs)
```

2) during make check
```
[ 19%] Building CXX object tests/CMakeFiles/BehaviourTest.dir/src/Mazars-generic.cxx.o
In file included from /home/glatu/mfem-mgis/build/tests/src/Mazars-generic.cxx:27:
/home/glatu/mfem-mgis/tests/Mazars.mfront: Dans l'instanciation de « tfel::material::Mazars<hypothesis, Type, false>::IntegrationResult tfel::material::Mazars<hypothesis, Type, false>::integrate(tfel::material::Mazars<hypothesis, Type, false>::SMFlag, tfel::material::Mazars<hypothesis, Type, false>::SMType) [avec tfel::material::ModellingHypothesis::Hypothesis hypothesis = (tfel::material::ModellingHypothesis::Hypothesis)0; Type = double; tfel::material::Mazars<hypothesis, Type, false>::IntegrationResult = tfel::material::MechanicalBehaviourBase::IntegrationResult; tfel::material::Mazars<hypothesis, Type, false>::SMFlag = tfel::material::TangentOperatorTraits<(tfel::material::MechanicalBehaviourBase::BehaviourType)1>::SMFlag; tfel::material::Mazars<hypothesis, Type, false>::SMType = tfel::material::MechanicalBehaviourBase::SMType] » :
/home/glatu/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.1.0/tfel-master-5ovl7z24xzov5n3lxkidemdg6dnkcgr4/include/MFront/GenericBehaviour/Integrate.hxx:244:18:   requis par « int mfront::gb::integrate(mfront_gb_BehaviourData&, typename Behaviour::SMFlag, tfel::material::OutOfBoundsPolicy) [avec Behaviour = tfel::material::Mazars<(tfel::material::ModellingHypothesis::Hypothesis)0, double, false>; mfront_gb_BehaviourData = mfront_gb_BehaviourData; typename Behaviour::SMFlag = tfel::material::TangentOperatorTraits<(tfel::material::MechanicalBehaviourBase::BehaviourType)1>::SMFlag] »
/home/glatu/mfem-mgis/build/tests/src/Mazars-generic.cxx:172:117:   requis depuis ici
/home/glatu/mfem-mgis/tests/Mazars.mfront:57:39: warning: comparer des nombres flottants à l'aide de == ou != n'est pas sûr [-Wfloat-equal]
   if ((min(s1, min(s2, s3)) < 0.) && (r == 0.)) {
                                    ~~~^~~~~~
```

Thanks for your help.