### PR TITLE
Enabling configuration with built-in mfem instead of installed mfem :

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,17 @@ if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
 endif(CMAKE_BUILD_TYPE STREQUAL "Coverage")
 
 # MFEM
-find_package(MFEM REQUIRED)
+if (NOT TARGET mfem)
+  message(STATUS "Searching for MFEM")
+  find_package(MFEM REQUIRED)
+else(NOT TARGET mfem)
+   message(STATUS "MFEM target already set")
+endif(NOT TARGET mfem)
+
 if (MFEM_USE_MPI)
   message(STATUS "MFEM: using MPI, so mfem_mgis will use MPI")
   find_package(MPI REQUIRED)
-endif()
+endif(MFEM_USE_MPI)
 
 # MFontGenericInterface
 find_package (MFrontGenericInterface REQUIRED)
@@ -60,11 +66,21 @@ set(CTEST_CONFIGURATION_TYPE "${JOB_BUILD_CONFIGURATION}")
 # (must be placed *before* any add_subdirectory, cmake bug ?)
 enable_testing()
 if(CMAKE_CONFIGURATION_TYPES)
-  add_custom_target(check COMMAND 
-    ${CMAKE_CTEST_COMMAND} -T test -C $<CONFIGURATION>)
+   if (NOT TARGET check)
+      add_custom_target(check COMMAND 
+         ${CMAKE_CTEST_COMMAND} -T test -C $<CONFIGURATION>)
+   else(NOT TARGET check)
+      add_custom_target(mgis_check COMMAND 
+         ${CMAKE_CTEST_COMMAND} -T test -C $<CONFIGURATION>)
+   endif(NOT TARGET check)
 else(CMAKE_CONFIGURATION_TYPES)
-  add_custom_target(check COMMAND 
-    ${CMAKE_CTEST_COMMAND} -T test )
+   if (NOT TARGET check)
+      add_custom_target(check COMMAND 
+      ${CMAKE_CTEST_COMMAND} -T test )
+   else(NOT TARGET check)
+      add_custom_target(mgis_check COMMAND 
+      ${CMAKE_CTEST_COMMAND} -T test )
+   endif(NOT TARGET check)
 endif(CMAKE_CONFIGURATION_TYPES)
 
 add_subdirectory(docs)

--- a/cmake/modules/mfem-mgis.cmake
+++ b/cmake/modules/mfem-mgis.cmake
@@ -13,7 +13,8 @@ function(mfem_mgis_library name)
     PUBLIC $<INSTALL_INTERFACE:include>
   )
   target_include_directories(${name}
-	PRIVATE "${MFEM_INCLUDE_DIRS}")
+    SYSTEM
+	PUBLIC "$<BUILD_INTERFACE:${MFEM_INCLUDE_DIRS}>")
   target_link_libraries(${name} 
     PUBLIC mgis::MFrontGenericInterface
     PUBLIC mfem)

--- a/cmake/modules/mfem-mgis.cmake
+++ b/cmake/modules/mfem-mgis.cmake
@@ -13,8 +13,7 @@ function(mfem_mgis_library name)
     PUBLIC $<INSTALL_INTERFACE:include>
   )
   target_include_directories(${name}
-    SYSTEM
-	PUBLIC "${MFEM_INCLUDE_DIRS}")
+	PRIVATE "${MFEM_INCLUDE_DIRS}")
   target_link_libraries(${name} 
     PUBLIC mgis::MFrontGenericInterface
     PUBLIC mfem)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,19 +8,18 @@ add_executable(PeriodicTest
   EXCLUDE_FROM_ALL
   PeriodicTest.cxx)
 target_link_libraries(PeriodicTest PRIVATE mfem)
-target_link_libraries(PeriodicTest
-  PRIVATE MFEMMGIS)
+target_link_libraries(PeriodicTest PRIVATE MFEMMGIS)
 target_include_directories(PeriodicTest PRIVATE "${MFEM_INCLUDE_DIRS}")
-  add_dependencies(check PeriodicTest)
+add_dependencies(check PeriodicTest)
 
 function(add_periodic_test ncase nsolver)
   set(test "PeriodicTest-${ncase}-${nsolver}")
   add_test(NAME ${test}
-   COMMAND PeriodicTest 
-   "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube_2mat_per.mesh"
-   "--library" "$<TARGET_FILE:BehaviourTest>"
-   "--test-case" "${ncase}"
-   "--linearsolver" "${nsolver}")
+    COMMAND PeriodicTest 
+    "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube_2mat_per.mesh"
+    "--library" "$<TARGET_FILE:BehaviourTest>"
+    "--test-case" "${ncase}"
+    "--linearsolver" "${nsolver}")
   if((CMAKE_HOST_WIN32) AND (NOT MSYS))
     set_property(TEST ${test}
       PROPERTY DEPENDS BehaviourTest
@@ -41,20 +40,19 @@ add_executable(UniaxialTensileTest
   EXCLUDE_FROM_ALL
   UniaxialTensileTest.cxx)
 target_link_libraries(UniaxialTensileTest PRIVATE mfem)
-target_link_libraries(UniaxialTensileTest
-  PRIVATE MFEMMGIS)
+target_link_libraries(UniaxialTensileTest PRIVATE MFEMMGIS)
 target_include_directories(UniaxialTensileTest PRIVATE "${MFEM_INCLUDE_DIRS}")
 add_dependencies(check UniaxialTensileTest)
 
 function(add_unilateral_test behaviour internal_state_variable)
   set(test "UniaxialTensileTest-${behaviour}")
   add_test(NAME ${test}
-   COMMAND UniaxialTensileTest
-   "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube.mesh"
-   "--library" "$<TARGET_FILE:BehaviourTest>"
-   "--behaviour" "${behaviour}"
-   "--reference-file" "${CMAKE_CURRENT_SOURCE_DIR}/references/${behaviour}.ref"
-   "--internal-state-variable" "${internal_state_variable}")
+    COMMAND UniaxialTensileTest
+    "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube.mesh"
+    "--library" "$<TARGET_FILE:BehaviourTest>"
+    "--behaviour" "${behaviour}"
+    "--reference-file" "${CMAKE_CURRENT_SOURCE_DIR}/references/${behaviour}.ref"
+    "--internal-state-variable" "${internal_state_variable}")
   if((CMAKE_HOST_WIN32) AND (NOT MSYS))
     set_property(TEST ${test}
       PROPERTY DEPENDS BehaviourTest
@@ -75,19 +73,18 @@ if (MFEM_USE_MPI)
     PeriodicTest.cxx)
   target_link_libraries(PeriodicTestP PRIVATE mfem)
   set_target_properties(PeriodicTestP PROPERTIES COMPILE_FLAGS "-DDO_USE_MPI" )
-  target_link_libraries(PeriodicTestP
-    PRIVATE MFEMMGIS)
+  target_link_libraries(PeriodicTestP PRIVATE MFEMMGIS)
   target_include_directories(PeriodicTestP PRIVATE "${MFEM_INCLUDE_DIRS}")
   add_dependencies(check PeriodicTestP)
-  
+
   function(add_periodic_testp ncase nsolver nbprocs)
     set(test "PeriodicTestP-${ncase}-${nsolver}-${nbprocs}")
     add_test(NAME ${test}
-     COMMAND mpirun -n ${nbprocs} PeriodicTestP 
-     "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube_2mat_per.mesh"
-     "--library" "$<TARGET_FILE:BehaviourTest>"
-     "--test-case" "${ncase}"
-     "--linearsolver" "${nsolver}")
+      COMMAND mpirun -n ${nbprocs} PeriodicTestP 
+      "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube_2mat_per.mesh"
+      "--library" "$<TARGET_FILE:BehaviourTest>"
+      "--test-case" "${ncase}"
+      "--linearsolver" "${nsolver}")
     if((CMAKE_HOST_WIN32) AND (NOT MSYS))
       set_property(TEST ${test}
         PROPERTY DEPENDS BehaviourTest
@@ -97,11 +94,11 @@ if (MFEM_USE_MPI)
         PROPERTY DEPENDS BehaviourTest)
     endif((CMAKE_HOST_WIN32) AND (NOT MSYS))
   endfunction(add_periodic_testp)
-  
+
   foreach(ncase RANGE 0 0)
     foreach(nsolver RANGE 1 1)
       foreach(nbprocs RANGE 1 4 3)
-	add_periodic_testp(${ncase} ${nsolver} ${nbprocs})
+        add_periodic_testp(${ncase} ${nsolver} ${nbprocs})
       endforeach(nbprocs)
     endforeach(nsolver)
   endforeach(ncase)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,8 +7,10 @@ mfront_behaviours_check_library(BehaviourTest
 add_executable(PeriodicTest
   EXCLUDE_FROM_ALL
   PeriodicTest.cxx)
+target_link_libraries(PeriodicTest PRIVATE mfem)
 target_link_libraries(PeriodicTest
   PRIVATE MFEMMGIS)
+target_include_directories(PeriodicTest PRIVATE "${MFEM_INCLUDE_DIRS}")
   add_dependencies(check PeriodicTest)
 
 function(add_periodic_test ncase nsolver)
@@ -38,8 +40,10 @@ endforeach(ncase)
 add_executable(UniaxialTensileTest
   EXCLUDE_FROM_ALL
   UniaxialTensileTest.cxx)
+target_link_libraries(UniaxialTensileTest PRIVATE mfem)
 target_link_libraries(UniaxialTensileTest
   PRIVATE MFEMMGIS)
+target_include_directories(UniaxialTensileTest PRIVATE "${MFEM_INCLUDE_DIRS}")
 add_dependencies(check UniaxialTensileTest)
 
 function(add_unilateral_test behaviour internal_state_variable)
@@ -69,9 +73,11 @@ if (MFEM_USE_MPI)
   add_executable(PeriodicTestP
     EXCLUDE_FROM_ALL
     PeriodicTest.cxx)
+  target_link_libraries(PeriodicTestP PRIVATE mfem)
   set_target_properties(PeriodicTestP PROPERTIES COMPILE_FLAGS "-DDO_USE_MPI" )
   target_link_libraries(PeriodicTestP
     PRIVATE MFEMMGIS)
+  target_include_directories(PeriodicTestP PRIVATE "${MFEM_INCLUDE_DIRS}")
   add_dependencies(check PeriodicTestP)
   
   function(add_periodic_testp ncase nsolver nbprocs)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,19 +7,18 @@ mfront_behaviours_check_library(BehaviourTest
 add_executable(PeriodicTest
   EXCLUDE_FROM_ALL
   PeriodicTest.cxx)
-target_link_libraries(PeriodicTest PRIVATE mfem)
-target_link_libraries(PeriodicTest PRIVATE MFEMMGIS)
-target_include_directories(PeriodicTest PRIVATE "${MFEM_INCLUDE_DIRS}")
-add_dependencies(check PeriodicTest)
+target_link_libraries(PeriodicTest
+  PRIVATE MFEMMGIS)
+  add_dependencies(check PeriodicTest)
 
 function(add_periodic_test ncase nsolver)
   set(test "PeriodicTest-${ncase}-${nsolver}")
   add_test(NAME ${test}
-    COMMAND PeriodicTest 
-    "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube_2mat_per.mesh"
-    "--library" "$<TARGET_FILE:BehaviourTest>"
-    "--test-case" "${ncase}"
-    "--linearsolver" "${nsolver}")
+   COMMAND PeriodicTest 
+   "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube_2mat_per.mesh"
+   "--library" "$<TARGET_FILE:BehaviourTest>"
+   "--test-case" "${ncase}"
+   "--linearsolver" "${nsolver}")
   if((CMAKE_HOST_WIN32) AND (NOT MSYS))
     set_property(TEST ${test}
       PROPERTY DEPENDS BehaviourTest
@@ -39,20 +38,19 @@ endforeach(ncase)
 add_executable(UniaxialTensileTest
   EXCLUDE_FROM_ALL
   UniaxialTensileTest.cxx)
-target_link_libraries(UniaxialTensileTest PRIVATE mfem)
-target_link_libraries(UniaxialTensileTest PRIVATE MFEMMGIS)
-target_include_directories(UniaxialTensileTest PRIVATE "${MFEM_INCLUDE_DIRS}")
+target_link_libraries(UniaxialTensileTest
+  PRIVATE MFEMMGIS)
 add_dependencies(check UniaxialTensileTest)
 
 function(add_unilateral_test behaviour internal_state_variable)
   set(test "UniaxialTensileTest-${behaviour}")
   add_test(NAME ${test}
-    COMMAND UniaxialTensileTest
-    "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube.mesh"
-    "--library" "$<TARGET_FILE:BehaviourTest>"
-    "--behaviour" "${behaviour}"
-    "--reference-file" "${CMAKE_CURRENT_SOURCE_DIR}/references/${behaviour}.ref"
-    "--internal-state-variable" "${internal_state_variable}")
+   COMMAND UniaxialTensileTest
+   "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube.mesh"
+   "--library" "$<TARGET_FILE:BehaviourTest>"
+   "--behaviour" "${behaviour}"
+   "--reference-file" "${CMAKE_CURRENT_SOURCE_DIR}/references/${behaviour}.ref"
+   "--internal-state-variable" "${internal_state_variable}")
   if((CMAKE_HOST_WIN32) AND (NOT MSYS))
     set_property(TEST ${test}
       PROPERTY DEPENDS BehaviourTest
@@ -71,20 +69,19 @@ if (MFEM_USE_MPI)
   add_executable(PeriodicTestP
     EXCLUDE_FROM_ALL
     PeriodicTest.cxx)
-  target_link_libraries(PeriodicTestP PRIVATE mfem)
   set_target_properties(PeriodicTestP PROPERTIES COMPILE_FLAGS "-DDO_USE_MPI" )
-  target_link_libraries(PeriodicTestP PRIVATE MFEMMGIS)
-  target_include_directories(PeriodicTestP PRIVATE "${MFEM_INCLUDE_DIRS}")
+  target_link_libraries(PeriodicTestP
+    PRIVATE MFEMMGIS)
   add_dependencies(check PeriodicTestP)
-
+  
   function(add_periodic_testp ncase nsolver nbprocs)
     set(test "PeriodicTestP-${ncase}-${nsolver}-${nbprocs}")
     add_test(NAME ${test}
-      COMMAND mpirun -n ${nbprocs} PeriodicTestP 
-      "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube_2mat_per.mesh"
-      "--library" "$<TARGET_FILE:BehaviourTest>"
-      "--test-case" "${ncase}"
-      "--linearsolver" "${nsolver}")
+     COMMAND mpirun -n ${nbprocs} PeriodicTestP 
+     "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube_2mat_per.mesh"
+     "--library" "$<TARGET_FILE:BehaviourTest>"
+     "--test-case" "${ncase}"
+     "--linearsolver" "${nsolver}")
     if((CMAKE_HOST_WIN32) AND (NOT MSYS))
       set_property(TEST ${test}
         PROPERTY DEPENDS BehaviourTest
@@ -94,11 +91,11 @@ if (MFEM_USE_MPI)
         PROPERTY DEPENDS BehaviourTest)
     endif((CMAKE_HOST_WIN32) AND (NOT MSYS))
   endfunction(add_periodic_testp)
-
+  
   foreach(ncase RANGE 0 0)
     foreach(nsolver RANGE 1 1)
       foreach(nbprocs RANGE 1 4 3)
-        add_periodic_testp(${ncase} ${nsolver} ${nbprocs})
+	add_periodic_testp(${ncase} ${nsolver} ${nbprocs})
       endforeach(nbprocs)
     endforeach(nsolver)
   endforeach(ncase)


### PR DESCRIPTION
I'm am trying to compile mfem and mfem-mgis as two cmake subprojects of the same project.
To do so, I had to modify some CMake scripts.
This pull request is a first version in order to begin the discussion, I'm not completely sure of what I've done but it seems to work.
Here is what I've done : 
 - Detect if the mfem is defined, if so, no call to find-package(mfem)
 - Detect if the check target is defined, if so, rename check target to mgis_check to prevent conflict with mfem check target.
 - Putting MFEM include directory in PRIVATE and add MFEM include for the examples

As it was, I had Cmake errors telling me that an include directory was in the source directory.
The correction I found was to move mfem include directory from PUBLIC to PRIVATE and add the mfem directory to the examples.

