### PR TITLE
Add external repository for storing mesh, and add an example case named ssna303

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,21 @@ endif(CMAKE_CONFIGURATION_TYPES)
 
 mfem_mgis_buildenv()
 
+
+include(FetchContent)
+FetchContent_Declare(mfem-mgis-data
+  GIT_REPOSITORY https://github.com/latug0/mfem-mgis-data.git
+  GIT_TAG master
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  )
+
+FetchContent_GetProperties(mfem-mgis-data)
+if(NOT mfem-mgis-data_POPULATED)
+  FetchContent_Populate(mfem-mgis-data)
+endif()
+
+
 add_subdirectory(docs)
 add_subdirectory(include)
 add_subdirectory(src)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,4 +7,5 @@ install(FILES
 install(FILES
   ex2/CMakeLists.txt
   ex2/ssna303.cxx
+  ${mfem-mgis-data_SOURCE_DIR}/mesh/ssna303.msh
   DESTINATION share/mfem-mgis/examples/ex2)

--- a/examples/ex2/CMakeLists.txt
+++ b/examples/ex2/CMakeLists.txt
@@ -11,30 +11,16 @@ find_package(MFEMMGIS REQUIRED)
 add_executable(Ssna303 ssna303.cxx)
 target_link_libraries(Ssna303 mfem-mgis::MFEMMGIS)
 set(MFEMMGIS_TESTDIR "${MFEMMGIS_DIR}/../examples/ex2")
-file(COPY ${MFEMMGIS_TESTDIR}/Plasticity.mfront
+file(COPY
+  ${MFEMMGIS_TESTDIR}/Plasticity.mfront
+  ${MFEMMGIS_TESTDIR}/ssna303.msh
   DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+
 add_custom_target(mfront
   COMMAND mfront --obuild --interface=generic Plasticity.mfront
   COMMENT "Performing mfront code generation")
 add_dependencies(Ssna303 mfront)
 
-
-Include(ExternalProject)
-ExternalProject_Add(ssna303_mesh_download
-    PREFIX mesh
-    URL https://icecube-eu-290.icedrive.io/download?p=_QX5pCKPMSnjByW6RnzM2yTxA8xs1QC4c2B.jUCE_u6lhrLk9nbi2fYCrTU2NNC_Dgg0pbW.Y2iAFsZt2WdVE3F9Zde1IFREqF.SUs9PStV4MjFF0a1eSAUHDFXwi0mCxNkJ84d4gbK7vdAAIRByVTvO5FpkoqpgVNtyMzkGniuuxm4xdKaxjOlhOT92sFcUb4aMhvrdvvauOL7vnfe5hA--
-    URL_HASH SHA512=11a19d29e440c804930e6bf68ac81ce9233d40972e816daead0a27fefc0bc7e57c36f55578b5a123ccbdf15efb76df834536d9e9bf07b39704c0f19e4f41a0d5
-    DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}
-    DOWNLOAD_NAME ssna303.msh
-    DOWNLOAD_NO_EXTRACT 1
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-    LOG_DOWNLOAD ON
-    LOG_CONFIGURE OFF
-    LOG_BUILD OFF
-    )
-add_dependencies(Ssna303 ssna303_mesh_download)
 
 
 

--- a/examples/ex2/ssna303.cxx
+++ b/examples/ex2/ssna303.cxx
@@ -124,9 +124,9 @@ int main(int argc, char** argv) {
       // resolution
       auto ct = t;
       auto dt2 = dt;
-      auto nsteps = mfem_mgis::size_type{1};
-      auto niter  = mfem_mgis::size_type{0};
-      while (nsteps != 0) {
+      auto locsteps = mfem_mgis::size_type{1};
+      auto lociter = mfem_mgis::size_type{0};
+      while (locsteps != 0) {
         auto converged = true;
         try {
           problem.solve(ct, dt2);
@@ -140,15 +140,15 @@ int main(int argc, char** argv) {
 	
         //      const auto converged = problem.solve(ct, dt2);
         if (converged) {
-          --nsteps;
+          --locsteps;
           ct += dt2;
         } else {
-          std::cout << "\nsubstep: " << niter << '\n';
-          nsteps *= 2;
+          std::cout << "\nsubstep: " << lociter << '\n';
+          locsteps *= 2;
           dt2 /= 2;
-          ++niter;
+          ++lociter;
           problem.revert();
-          if (niter == 10) {
+          if (lociter == 10) {
             mgis::raise("maximum number of substeps");
           }
         }

--- a/examples/ex2/ssna303.cxx
+++ b/examples/ex2/ssna303.cxx
@@ -103,6 +103,8 @@ int main(int argc, char** argv) {
   // selection of the linear solver
 #if defined (MFEM_USE_MUMPS)
     problem.setLinearSolver("MUMPSSolver", {});
+#elif defined (MFEM_USE_SUITESPARSE)
+    problem.setLinearSolver("UMFPackSolver", {});
 #else
     problem.setLinearSolver("CGSolver", {{"VerbosityLevel", 1},
                                          {"RelativeTolerance", 1e-12},

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,3 +147,6 @@ endif(MFEM_MGIS_HAVE_TFEL)
 
 install(FILES Plasticity.mfront cube.mesh
   DESTINATION "share/mfem-mgis/examples/ex1")
+
+install(FILES Plasticity.mfront 
+  DESTINATION "share/mfem-mgis/examples/ex2")


### PR DESCRIPTION
I wish to store meshes, inputs and validation data for large examples on a separate repository (named mfem-mgis-data). It will permit to avoid weighing too much on the main repo. Furthermore, this external repo will not require to have a *clean* history (one can revise git history if needed, which is not the cas for the main repo storing code).
The Cmake feature named FetchContent is used to deal with the new repo.

