### PR TITLE
Postprocess to compute stress and strain at nodal values 

### DIFF
--- a/include/MFEMMGIS/Material.hxx
+++ b/include/MFEMMGIS/Material.hxx
@@ -115,7 +115,7 @@ namespace mfem_mgis {
    */
   MFEM_MGIS_EXPORT PartialQuadratureFunction
   getGradient(Material &,
-              const mgis::string_view &,
+              const mgis::string_view,
               const Material::StateSelection = Material::END_OF_TIME_STEP);
   /*!
    * \return a partial quadrature function for the given thermodynamic force
@@ -125,7 +125,7 @@ namespace mfem_mgis {
    */
   MFEM_MGIS_EXPORT PartialQuadratureFunction getThermodynamicForce(
       Material &,
-      const mgis::string_view &,
+      const mgis::string_view,
       const Material::StateSelection = Material::END_OF_TIME_STEP);
   /*!
    * \return a partial quadrature function for the given state variable
@@ -135,7 +135,7 @@ namespace mfem_mgis {
    */
   MFEM_MGIS_EXPORT PartialQuadratureFunction getInternalStateVariable(
       Material &,
-      const mgis::string_view &,
+      const mgis::string_view,
       const Material::StateSelection = Material::END_OF_TIME_STEP);
 
 }  // end of namespace mfem_mgis

--- a/include/MFEMMGIS/NonLinearEvolutionProblemImplementation.hxx
+++ b/include/MFEMMGIS/NonLinearEvolutionProblemImplementation.hxx
@@ -48,6 +48,10 @@ namespace mfem_mgis {
         std::shared_ptr<FiniteElementDiscretization>,
         const Hypothesis,
         const Parameters&);
+    //! \return the mesh
+    Mesh<true>& getMesh();
+    //! \return the mesh
+    const Mesh<true>& getMesh() const;
     //! \return the finite element space
     FiniteElementSpace<true>& getFiniteElementSpace();
     //! \return the finite element space
@@ -95,6 +99,10 @@ namespace mfem_mgis {
         std::shared_ptr<FiniteElementDiscretization>,
         const Hypothesis,
         const Parameters&);
+    //! \return the mesh
+    Mesh<false>& getMesh();
+    //! \return the mesh
+    const Mesh<false>& getMesh() const;
     //! \return the finite element space
     FiniteElementSpace<false>& getFiniteElementSpace();
     //! \return the finite element space

--- a/include/MFEMMGIS/Parameter.hxx
+++ b/include/MFEMMGIS/Parameter.hxx
@@ -23,7 +23,7 @@ namespace mfem_mgis {
   //! \brief a simple alias
   using ParameterVariant = std::variant<std::monostate,
                                         bool,
-                                        int,
+                                        size_type,
                                         real,
                                         std::string,
                                         std::vector<Parameter>,

--- a/include/MFEMMGIS/Parameters.hxx
+++ b/include/MFEMMGIS/Parameters.hxx
@@ -96,6 +96,7 @@ namespace mfem_mgis {
     ~Parameters();
   };  // end of struct Parameters
 
+
   /*!
    * \param[in] parameters: parameters
    * \param[in] names: list of valid parameters names

--- a/include/MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.hxx
+++ b/include/MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.hxx
@@ -1,0 +1,90 @@
+/*!
+ * \file   include/MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.hxx
+ * \brief
+ * \author Thomas Helfer
+ * \date   24/03/2021
+ */
+
+#ifndef LIB_MFEMMGIS_PARAVIEWEXPORTINTEGRATIONPOINTRESULTSATNODES_HXX
+#define LIB_MFEMMGIS_PARAVIEWEXPORTINTEGRATIONPOINTRESULTSATNODES_HXX
+
+#include <memory>
+#include "mfem/fem/datacollection.hpp"
+#include "MFEMMGIS/Config.hxx"
+#include "MFEMMGIS/Parameters.hxx"
+#include "MFEMMGIS/PostProcessing.hxx"
+
+namespace mfem_mgis {
+
+  /*!
+   * \brief a post-processing to export integration points results to paraview
+   * after projecting them to nodes
+   */
+  template <bool parallel>
+  struct ParaviewExportIntegrationPointResultsAtNodes final
+      : public PostProcessing<parallel> {
+    /*!
+     * \brief constructor
+     * \param[in] p: non linear problem
+     * \param[in] params: parameters passed to the post-processing
+     */
+    ParaviewExportIntegrationPointResultsAtNodes(
+        NonLinearEvolutionProblemImplementation<parallel>&, const Parameters&);
+    //
+    void execute(NonLinearEvolutionProblemImplementation<parallel>&,
+                 const real,
+                 const real) override;
+    //! \brief destructor
+    ~ParaviewExportIntegrationPointResultsAtNodes() override;
+
+   private:
+    struct IntegrationPointResult {
+      //! \brief enumeration of the kind of results that can be post-processed.
+      enum Category {
+        GRADIENTS,
+        THERMODYNAMIC_FORCES,
+        INTERNAL_STATE_VARIABLES
+      };
+      //! \brief name of the result
+      std::string name;
+      //! \brief number of components
+      size_type number_of_components;
+      //! \brief kind of results treated
+      Category category;
+      //! \brief finite element space
+      std::unique_ptr<FiniteElementSpace<parallel>> fespace;
+      //! \brief grid function
+      std::unique_ptr<GridFunction<parallel>> f;
+    };
+    //
+    struct ResultCoefficientBase;
+    //
+    struct ScalarResultCoefficient;
+    //
+    struct MultiComponentsResultCoefficient;
+    /*!
+     * \brief get information about the given result (number of components and
+     * category)
+     */
+    void getResultDescription(
+        IntegrationPointResult&,
+        const NonLinearEvolutionProblemImplementation<parallel>&);
+    //! \brief update the results
+    void updateResultGridFunction(
+        IntegrationPointResult&,
+        NonLinearEvolutionProblemImplementation<parallel>&);
+    //! \brief paraview exporter
+    mfem::ParaViewDataCollection exporter;
+    //! \brief list of material' identifiers
+    std::vector<size_type> materials_identifiers;
+    //! \brief list of results
+    std::vector<IntegrationPointResult> results;
+    //! \brief number of records
+    size_type cycle;
+  };  // end of struct ParaviewExportIntegrationPointResultsAtNodes
+
+}  // end of namespace mfem_mgis
+
+#include "MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.ixx"
+
+#endif /* LIB_MFEMMGIS_PARAVIEWEXPORTINTEGRATIONPOINTRESULTSATNODES_HXX */

--- a/include/MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.ixx
+++ b/include/MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.ixx
@@ -22,10 +22,6 @@ namespace mfem_mgis {
       // creating the partial functions per materials
       for (const auto& mid : mids) {
         auto& m = p.getMaterial(mid);
-        if (m.n == 0) {
-          // empty materials may exists in parallel
-          continue;
-        }
         if (r.category == IntegrationPointResult::GRADIENTS) {
           this->functions.insert({mid, getGradient(m, r.name)});
         } else if (r.category == IntegrationPointResult::THERMODYNAMIC_FORCES) {
@@ -67,7 +63,7 @@ namespace mfem_mgis {
       const auto mid = tr.Attribute;
       const auto p = this->functions.find(mid);
       if (p == this->functions.end()) {
-        return 0;
+        return 0.;
       }
       return p->second.getIntegrationPointValue(tr.ElementNo, i.index);
     }  // end of Eval

--- a/include/MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.ixx
+++ b/include/MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.ixx
@@ -149,15 +149,9 @@ namespace mfem_mgis {
       // creating the finite element space that will support the result grid
       // function
       auto fes = p.getFiniteElementSpace();
-      if constexpr (parallel) {
-        r.fespace = std::make_unique<FiniteElementSpace<parallel>>(
-            fes.GetParMesh(), fes.FEColl(), r.number_of_components,
-            fes.GetOrdering());
-      } else {
-        r.fespace = std::make_unique<FiniteElementSpace<parallel>>(
-            fes.GetMesh(), fes.FEColl(), r.number_of_components,
-            fes.GetOrdering());
-      }
+      r.fespace = std::make_unique<FiniteElementSpace<parallel>>(
+          &(p.getMesh()), fes.FEColl(), r.number_of_components,
+          fes.GetOrdering());
       // grid function
       r.f = std::make_unique<GridFunction<parallel>>(r.fespace.get());
       // registring

--- a/include/MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.ixx
+++ b/include/MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.ixx
@@ -1,0 +1,253 @@
+/*!
+ * \file   include/MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.ixx
+ * \brief
+ * \author Thomas Helfer
+ * \date   18/08/2021
+ */
+
+#ifndef LIB_MFEMMGIS_PARAVIEWEXPORTINTEGRATIONPOINTRESULTSATNODES_IXX
+#define LIB_MFEMMGIS_PARAVIEWEXPORTINTEGRATIONPOINTRESULTSATNODES_IXX
+
+#include "MFEMMGIS/NonLinearEvolutionProblemImplementation.hxx"
+
+namespace mfem_mgis {
+
+  template <bool parallel>
+  struct ParaviewExportIntegrationPointResultsAtNodes<
+      parallel>::ResultCoefficientBase {
+    //
+    ResultCoefficientBase(const IntegrationPointResult& r,
+                          NonLinearEvolutionProblemImplementation<parallel>& p,
+                          const std::vector<size_type>& mids) {
+      // creating the partial functions per materials
+      for (const auto& mid : mids) {
+        auto& m = p.getMaterial(mid);
+        if (r.category == IntegrationPointResult::GRADIENTS) {
+          this->functions.insert({mid, getGradient(m, r.name)});
+        } else if (r.category == IntegrationPointResult::THERMODYNAMIC_FORCES) {
+          this->functions.insert({mid, getThermodynamicForce(m, r.name)});
+        } else {
+          this->functions.insert({mid, getInternalStateVariable(m, r.name)});
+        }
+      }
+    }
+    //
+    ResultCoefficientBase(ResultCoefficientBase&&) = default;
+    ResultCoefficientBase(const ResultCoefficientBase&) = default;
+    ResultCoefficientBase& operator=(ResultCoefficientBase&&) = default;
+    ResultCoefficientBase& operator=(const ResultCoefficientBase&) = default;
+
+   protected:
+    std::map<size_type, PartialQuadratureFunction> functions;
+  };  // end of ResultCoefficientBase
+
+  template <bool parallel>
+  struct ParaviewExportIntegrationPointResultsAtNodes<
+      parallel>::ScalarResultCoefficient : public ResultCoefficientBase,
+                                           public mfem::Coefficient {
+    //
+    ScalarResultCoefficient(
+        const IntegrationPointResult& r,
+        NonLinearEvolutionProblemImplementation<parallel>& p,
+        const std::vector<size_type>& mids)
+        : ResultCoefficientBase(r, p, mids) {}
+    //
+    ScalarResultCoefficient(ScalarResultCoefficient&&) = default;
+    ScalarResultCoefficient(const ScalarResultCoefficient&) = default;
+    ScalarResultCoefficient& operator=(ScalarResultCoefficient&&) = default;
+    ScalarResultCoefficient& operator=(const ScalarResultCoefficient&) =
+        default;
+    //
+    double Eval(mfem::ElementTransformation& tr,
+                const mfem::IntegrationPoint& i) override {
+      const auto mid = tr.Attribute;
+      const auto p = this->functions.find(mid);
+      if (p == this->functions.end()) {
+        return 0;
+      }
+      return p->second.getIntegrationPointValue(tr.ElementNo, i.index);
+    }  // end of Eval
+  };
+
+  template <bool parallel>
+  struct ParaviewExportIntegrationPointResultsAtNodes<
+      parallel>::MultiComponentsResultCoefficient
+      : public ResultCoefficientBase,
+        public mfem::VectorCoefficient {
+    //
+    MultiComponentsResultCoefficient(
+        const IntegrationPointResult& r,
+        NonLinearEvolutionProblemImplementation<parallel>& p,
+        const std::vector<size_type>& mids)
+        : ResultCoefficientBase(r, p, mids),
+          mfem::VectorCoefficient(r.number_of_components) {}
+    //
+    MultiComponentsResultCoefficient(MultiComponentsResultCoefficient&&) =
+        default;
+    MultiComponentsResultCoefficient(const MultiComponentsResultCoefficient&) =
+        default;
+    MultiComponentsResultCoefficient& operator=(
+        MultiComponentsResultCoefficient&&) = default;
+    MultiComponentsResultCoefficient& operator=(
+        const MultiComponentsResultCoefficient&) = default;
+    //
+    void Eval(mfem::Vector& values,
+              mfem::ElementTransformation& tr,
+              const mfem::IntegrationPoint& ip) override {
+      const auto mid = tr.Attribute;
+      const auto p = this->functions.find(mid);
+      if (p == this->functions.end()) {
+        values = 0.;
+      } else {
+        const auto rvalues =
+            p->second.getIntegrationPointValues(tr.ElementNo, ip.index);
+        for (size_type i = 0; i != this->GetVDim(); ++i) {
+          values[i] = rvalues[i];
+        }
+      }
+    }  // end of Eval
+  };
+
+  template <bool parallel>
+  ParaviewExportIntegrationPointResultsAtNodes<parallel>::
+      ParaviewExportIntegrationPointResultsAtNodes(
+          NonLinearEvolutionProblemImplementation<parallel>& p,
+          const Parameters& params)
+      : exporter(get<std::string>(params, "OutputFileName"),
+                 p.getFiniteElementSpace().GetMesh()),
+        cycle(0) {
+    if (contains(params, "Materials")) {
+      for (const auto& mid : get<std::vector<Parameter>>(params, "Materials")) {
+        this->materials_identifiers.push_back(get<size_type>(mid));
+      }
+    } else {
+      this->materials_identifiers = p.getMaterialIdentifiers();
+    }
+    if (!contains(params, "ExportedResults")) {
+      raise(
+          "ParaviewExportIntegrationPointResultsAtNodes::"
+          "ParaviewExportIntegrationPointResultsAtNodes: "
+          "no results to export declared");
+    }
+    // total number of components of the exported field
+    for (const auto& rn :
+         get<std::vector<Parameter>>(params, "ExportedResults")) {
+      auto r = IntegrationPointResult{};
+      r.name = get<std::string>(rn);
+      this->getResultDescription(r, p);
+      // creating the finite element space that will support the result grid
+      // function
+      auto fes = p.getFiniteElementSpace();
+      if constexpr (parallel) {
+        r.fespace = std::make_unique<FiniteElementSpace<parallel>>(
+            fes.GetParMesh(), fes.FEColl(), r.number_of_components,
+            fes.GetOrdering());
+      } else {
+        r.fespace = std::make_unique<FiniteElementSpace<parallel>>(
+            fes.GetMesh(), fes.FEColl(), r.number_of_components,
+            fes.GetOrdering());
+      }
+      // grid function
+      r.f = std::make_unique<GridFunction<parallel>>(r.fespace.get());
+      // registring
+      this->exporter.RegisterField(r.name, r.f.get());
+      // saving
+      this->results.push_back(std::move(r));
+    }
+  }  // end of ParaviewExportIntegrationPointResultsAtNodes
+
+  template <bool parallel>
+  void ParaviewExportIntegrationPointResultsAtNodes<parallel>::execute(
+      NonLinearEvolutionProblemImplementation<parallel>& p,
+      const real t,
+      const real dt) {
+    this->exporter.SetCycle(this->cycle);
+    this->exporter.SetTime(t + dt);
+    // updating grid functions
+    for (auto& r : this->results) {
+      this->updateResultGridFunction(r, p);
+    }
+
+    // ??? does not work if not called. Don't know why...
+    //     this->result.SetFromTrueVector();
+    this->exporter.Save();
+    ++(this->cycle);
+  }  // end of execute
+
+  template <bool parallel>
+  void ParaviewExportIntegrationPointResultsAtNodes<parallel>::
+      updateResultGridFunction(
+          IntegrationPointResult& r,
+          NonLinearEvolutionProblemImplementation<parallel>& p) {
+    if (r.number_of_components == 1u) {
+      auto c = ScalarResultCoefficient(r, p, this->materials_identifiers);
+      r.f->ProjectDiscCoefficient(c, mfem::GridFunction::ARITHMETIC);
+    } else {
+      auto c =
+          MultiComponentsResultCoefficient(r, p, this->materials_identifiers);
+      r.f->ProjectDiscCoefficient(c, mfem::GridFunction::ARITHMETIC);
+    }
+  }  // end of updateResultGridFunction
+
+  template <bool parallel>
+  void
+  ParaviewExportIntegrationPointResultsAtNodes<parallel>::getResultDescription(
+      IntegrationPointResult& r,
+      const NonLinearEvolutionProblemImplementation<parallel>& p) {
+    using namespace mgis::behaviour;
+    auto c = typename IntegrationPointResult::Category{};
+    auto s = size_type{};
+    auto first = true;
+    if (this->materials_identifiers.empty()) {
+      raise("getResultDescription: empty list of material identifiers");
+    }
+    for (const auto& mid : this->materials_identifiers) {
+      const auto [c2, s2] = [
+        &p, &mid, &r
+      ]() -> std::tuple<typename IntegrationPointResult::Category, size_type> {
+        const auto& m = p.getMaterial(mid);
+        const auto& h = m.b.hypothesis;
+        if (contains(m.b.gradients, r.name)) {
+          return {IntegrationPointResult::GRADIENTS,
+                  getVariableSize(getVariable(m.b.gradients, r.name), h)};
+        } else if (contains(m.b.thermodynamic_forces, r.name)) {
+          return {IntegrationPointResult::THERMODYNAMIC_FORCES,
+                  getVariableSize(getVariable(m.b.thermodynamic_forces, r.name),
+                                  h)};
+        } else if (!contains(m.b.isvs, r.name)) {
+          raise("getResultDescription: no result '" + std::string(r.name) +
+                "' found for material '" + std::to_string(mid) + "'");
+        }
+        return {IntegrationPointResult::INTERNAL_STATE_VARIABLES,
+                getVariableSize(getVariable(m.b.isvs, r.name), h)};
+      }
+      ();
+      if (first) {
+        s = s2;
+        c = c2;
+      } else {
+        if (s != s2) {
+          raise(
+              "getResultDescription: inconsistent number of components of "
+              "field '" +
+              std::string(r.name) + "'");
+        }
+        if (c != c2) {
+          raise(
+              "getResultDescription: inconsistent nature for "
+              "field '" +
+              std::string(r.name) + "'");
+        }
+      }
+    }
+    r.category = c;
+    r.number_of_components = s;
+  }  // end of getResultDescription
+
+  template <bool parallel>
+  ParaviewExportIntegrationPointResultsAtNodes<
+      parallel>::~ParaviewExportIntegrationPointResultsAtNodes() = default;
+
+}  // end of namespace mfem_mgis
+
+#endif /* LIB_MFEMMGIS_PARAVIEWEXPORTINTEGRATIONPOINTRESULTSATNODES_IXX */

--- a/include/MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.ixx
+++ b/include/MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.ixx
@@ -22,6 +22,10 @@ namespace mfem_mgis {
       // creating the partial functions per materials
       for (const auto& mid : mids) {
         auto& m = p.getMaterial(mid);
+        if (m.n == 0) {
+          // empty materials may exists in parallel
+          continue;
+        }
         if (r.category == IntegrationPointResult::GRADIENTS) {
           this->functions.insert({mid, getGradient(m, r.name)});
         } else if (r.category == IntegrationPointResult::THERMODYNAMIC_FORCES) {

--- a/include/MFEMMGIS/ParaviewExportResults.hxx
+++ b/include/MFEMMGIS/ParaviewExportResults.hxx
@@ -37,9 +37,9 @@ namespace mfem_mgis {
    private:
     //! \brief paraview exporter
     mfem::ParaViewDataCollection exporter;
-    //! exported grid function
+    //! \brief exported grid function
     mfem_mgis::GridFunction<parallel> result;
-    //!
+    //! \brief number of records
     size_type cycle;
   };  // end of struct ParaviewExportResults
 

--- a/include/MFEMMGIS/ParaviewExportResults.ixx
+++ b/include/MFEMMGIS/ParaviewExportResults.ixx
@@ -22,6 +22,7 @@ namespace mfem_mgis {
         cycle(0) {
     auto& u1 = p.getUnknownsAtEndOfTheTimeStep();
     this->result.MakeTRef(&p.getFiniteElementSpace(), u1, 0);
+    // ??? does not work if not called. Don't know why...
     this->result.SetFromTrueVector();
     if (contains(params, "OutputFieldName")) {
       this->exporter.RegisterField(get<std::string>(params, "OutputFieldName"),
@@ -38,6 +39,7 @@ namespace mfem_mgis {
       const real dt) {
     this->exporter.SetCycle(this->cycle);
     this->exporter.SetTime(t + dt);
+    // ??? does not work if not called. Don't know why...
     this->result.SetFromTrueVector();
     this->exporter.Save();
     ++(this->cycle);

--- a/include/MFEMMGIS/ParaviewExportResults.ixx
+++ b/include/MFEMMGIS/ParaviewExportResults.ixx
@@ -22,8 +22,6 @@ namespace mfem_mgis {
         cycle(0) {
     auto& u1 = p.getUnknownsAtEndOfTheTimeStep();
     this->result.MakeTRef(&p.getFiniteElementSpace(), u1, 0);
-    // ??? does not work if not called. Don't know why...
-    this->result.SetFromTrueVector();
     if (contains(params, "OutputFieldName")) {
       this->exporter.RegisterField(get<std::string>(params, "OutputFieldName"),
                                    &(this->result));
@@ -39,7 +37,11 @@ namespace mfem_mgis {
       const real dt) {
     this->exporter.SetCycle(this->cycle);
     this->exporter.SetTime(t + dt);
-    // ??? does not work if not called. Don't know why...
+    // SetFromTrueVector needed here in MFEM for at least two rationales:
+    //    - it applies prolongation matrix (Non-Conforming mesh, BCs, AMR ...)
+    //      to set the values of some unkwown dofs deduced from known dofs
+    //    - exchange data between processes in order to retrieve information 
+    //      needed to perform the previous prolongation step
     this->result.SetFromTrueVector();
     this->exporter.Save();
     ++(this->cycle);

--- a/include/MFEMMGIS/PartialQuadratureFunction.hxx
+++ b/include/MFEMMGIS/PartialQuadratureFunction.hxx
@@ -124,9 +124,11 @@ namespace mfem_mgis {
     std::shared_ptr<const PartialQuadratureSpace> qspace;
     //! \brief underlying values
     mgis::span<real> values;
-    //! \brief storage for the values when the partial function holds the
-    //! values
-    std::vector<real> values_storage;
+    /*!
+     * \brief storage for the values when the partial function holds the
+     * values
+     */
+    std::vector<real> local_values_storage;
     //! \brief data stride
     size_type data_stride;
     //! \brief begin of the data

--- a/include/MFEMMGIS/PartialQuadratureFunction.hxx
+++ b/include/MFEMMGIS/PartialQuadratureFunction.hxx
@@ -109,7 +109,8 @@ namespace mfem_mgis {
      */
     mgis::span<const real> getIntegrationPointValues(const size_type,
                                                      const size_type) const;
-
+    //! \return the number of components
+    size_type getNumberOfComponents() const;
     //! \brief destructor
     ~PartialQuadratureFunction();
 

--- a/include/MFEMMGIS/PartialQuadratureFunction.ixx
+++ b/include/MFEMMGIS/PartialQuadratureFunction.ixx
@@ -53,6 +53,10 @@ namespace mfem_mgis {
         this->values.data() + this->getDataOffset(o), this->data_size);
   }  // end of getIntegrationPointValues
 
+  inline size_type PartialQuadratureFunction::getNumberOfComponents() const {
+    return this->data_size;
+  } // end of PartialQuadratureFunction::getNumberOfComponents
+
 }  // end of namespace mfem_mgis
 
 #endif /* LIB_MFEM_MGIS_PARTIALQUADRATUREFUNCTION_IXX */

--- a/src/FiniteElementDiscretization.cxx
+++ b/src/FiniteElementDiscretization.cxx
@@ -96,8 +96,7 @@ namespace mfem_mgis {
       reportUnsupportedParallelComputations();
 #endif /* MFEM_USE_MPI */
     } else {
-      this->sequential_mesh =
-        loadMeshSequential(mesh_file, 0, 1, true);
+      this->sequential_mesh = loadMeshSequential(mesh_file, 0, 1, true);
       for (size_type i = 0; i < nrefinement; ++i) {
         this->sequential_mesh->UniformRefinement();
       }
@@ -235,32 +234,31 @@ namespace mfem_mgis {
     return fed.getFiniteElementSpace<false>().GetTrueVSize();
   }  // end of getTrueVSize
 
-  std::shared_ptr<Mesh<false>>
-  loadMeshSequential(
-                     const std::string& mesh_name,
-                     int generate_edges,
-                     int refine,
-                     bool fix_orientation) {
+  std::shared_ptr<Mesh<false>> loadMeshSequential(const std::string& mesh_name,
+                                                  int generate_edges,
+                                                  int refine,
+                                                  bool fix_orientation) {
 #ifdef MFEM_USE_MED
     auto extension = getFileExt(mesh_name);
     if (extension == "med") {
       auto medmesh = std::make_shared<Mesh<false>>();
       std::string per_name = mesh_name;
-      per_name.replace (per_name.length()-4,4,".per");
+      per_name.replace(per_name.length() - 4, 4, ".per");
       std::ifstream per_file(per_name.c_str());
       if (per_file.good()) {
         medmesh->ImportMED(mesh_name, 0, per_name);
       } else {
         medmesh->ImportMED(mesh_name, 0, "");
-      } 
-      //medmesh->CheckElementOrientation(fix_orientation);
-      //medmesh->CheckBdrElementOrientation(fix_orientation);
+      }
+      // medmesh->CheckElementOrientation(fix_orientation);
+      // medmesh->CheckBdrElementOrientation(fix_orientation);
       return medmesh;
     }
-#endif  /* MFEM_USE_MED */
-    auto smesh = std::make_shared<Mesh<false>>(mesh_name.c_str(), generate_edges, refine);
+#endif /* MFEM_USE_MED */
+    auto smesh = std::make_shared<Mesh<false>>(mesh_name.c_str(),
+                                               generate_edges, refine);
     return smesh;
-    
+
   }  // end of loadMeshSequential
-  
+
 }  // end of namespace mfem_mgis

--- a/src/Material.cxx
+++ b/src/Material.cxx
@@ -191,7 +191,7 @@ namespace mfem_mgis {
     return m.s0;
   }
 
-  static PartialQuadratureFunction buidPartialQuadratureFunction(
+  static PartialQuadratureFunction buildPartialQuadratureFunction(
       std::shared_ptr<const PartialQuadratureSpace> qs,
       mgis::span<mgis::real> values,
       const std::vector<mgis::behaviour::Variable> &variables,
@@ -201,12 +201,12 @@ namespace mfem_mgis {
     const auto s =
         getVariableSize(mgis::behaviour::getVariable(variables, n), h);
     return PartialQuadratureFunction(qs, values, o, s);
-  }  // end of buidPartialQuadratureFunction
+  }  // end of buildPartialQuadratureFunction
 
   PartialQuadratureFunction getGradient(Material &m,
                                         const mgis::string_view n,
                                         const Material::StateSelection s) {
-    return buidPartialQuadratureFunction(m.getPartialQuadratureSpacePointer(),
+    return buildPartialQuadratureFunction(m.getPartialQuadratureSpacePointer(),
                                          getStateManager(m, s).gradients,
                                          m.b.gradients, n, m.b.hypothesis);
   }  // end of getGradient
@@ -215,7 +215,7 @@ namespace mfem_mgis {
       Material &m,
       const mgis::string_view n,
       const Material::StateSelection s) {
-    return buidPartialQuadratureFunction(
+    return buildPartialQuadratureFunction(
         m.getPartialQuadratureSpacePointer(),
         getStateManager(m, s).thermodynamic_forces, m.b.thermodynamic_forces, n,
         m.b.hypothesis);
@@ -223,7 +223,7 @@ namespace mfem_mgis {
 
   PartialQuadratureFunction getInternalStateVariable(
       Material &m, const mgis::string_view n, const Material::StateSelection s) {
-    return buidPartialQuadratureFunction(
+    return buildPartialQuadratureFunction(
         m.getPartialQuadratureSpacePointer(),
         getStateManager(m, s).internal_state_variables, m.b.isvs, n,
         m.b.hypothesis);

--- a/src/NonLinearEvolutionProblemImplementation.cxx
+++ b/src/NonLinearEvolutionProblemImplementation.cxx
@@ -118,13 +118,23 @@ namespace mfem_mgis {
     }
   }  // end of executePostProcessings
 
-  const FiniteElementSpace<true>&
-  NonLinearEvolutionProblemImplementation<true>::getFiniteElementSpace() const {
-    return this->fe_discretization->getFiniteElementSpace<true>();
-  }  // end of getFiniteElementSpace
+  Mesh<true>&
+  NonLinearEvolutionProblemImplementation<true>::getMesh() {
+    return this->fe_discretization->getMesh<true>();
+  }  // end of getMesh
+
+  const Mesh<true>&
+  NonLinearEvolutionProblemImplementation<true>::getMesh() const {
+    return this->fe_discretization->getMesh<true>();
+  }  // end of getMesh
 
   FiniteElementSpace<true>&
   NonLinearEvolutionProblemImplementation<true>::getFiniteElementSpace() {
+    return this->fe_discretization->getFiniteElementSpace<true>();
+  }  // end of getFiniteElementSpace
+
+  const FiniteElementSpace<true>&
+  NonLinearEvolutionProblemImplementation<true>::getFiniteElementSpace() const {
     return this->fe_discretization->getFiniteElementSpace<true>();
   }  // end of getFiniteElementSpace
 
@@ -206,6 +216,16 @@ namespace mfem_mgis {
       p->execute(*this, t, dt);
     }
   }  // end of executePostProcessings
+
+  Mesh<false>&
+  NonLinearEvolutionProblemImplementation<false>::getMesh() {
+    return this->fe_discretization->getMesh<false>();
+  }  // end of getMesh
+
+  const Mesh<false>&
+  NonLinearEvolutionProblemImplementation<false>::getMesh() const {
+    return this->fe_discretization->getMesh<false>();
+  }  // end of getMesh
 
   const FiniteElementSpace<false>& NonLinearEvolutionProblemImplementation<
       false>::getFiniteElementSpace() const {

--- a/src/PartialQuadratureFunction.cxx
+++ b/src/PartialQuadratureFunction.cxx
@@ -35,12 +35,12 @@ namespace mfem_mgis {
       const size_type db,
       const size_type ds)
       : qspace(s), values(v), data_begin(db) {
-    if (db < 0) {
+    if (this->data_begin < 0) {
       raise(
           "PartialQuadratureFunction::PartialQuadratureFunction: invalid "
           "start of the data");
     }
-    if (ds <= 0) {
+    if (ds < 0) {
       raise(
           "PartialQuadratureFunction::PartialQuadratureFunction: invalid "
           "data size");
@@ -53,15 +53,15 @@ namespace mfem_mgis {
           "values size");
     }
     this->data_stride = d.quot;
-    if (db > this->data_stride) {
+    if (this->data_begin >= this->data_stride) {
       raise(
           "PartialQuadratureFunction::PartialQuadratureFunction: invalid "
           "start of the data");
     }
     if (ds == std::numeric_limits<size_type>::max()) {
-      this->data_size = this->data_stride;
+      this->data_size = this->data_stride - this->data_begin;
     } else {
-      if (db + ds >= this->data_stride) {
+      if (this->data_begin + ds > this->data_stride) {
         raise(
             "PartialQuadratureFunction::PartialQuadratureFunction: invalid "
             "data range is outside the stride size");

--- a/src/PostProcessingFactory.cxx
+++ b/src/PostProcessingFactory.cxx
@@ -9,6 +9,7 @@
 #include "MGIS/Raise.hxx"
 #include "MFEMMGIS/PostProcessing.hxx"
 #include "MFEMMGIS/ParaviewExportResults.hxx"
+#include "MFEMMGIS/ParaviewExportIntegrationPointResultsAtNodes.hxx"
 #include "MFEMMGIS/MeanThermodynamicForces.hxx"
 #include "MFEMMGIS/ComputeResultantForceOnBoundary.hxx"
 #include "MFEMMGIS/PostProcessingFactory.hxx"
@@ -55,6 +56,13 @@ namespace mfem_mgis {
               [](NonLinearEvolutionProblemImplementation<true>& p,
                  const Parameters& params) {
                 return std::make_unique<ParaviewExportResults<true>>(p, params);
+              });
+    this->add("ParaviewExportIntegrationPointResultsAtNodes",
+              [](NonLinearEvolutionProblemImplementation<true>& p,
+                 const Parameters& params) {
+                return std::make_unique<
+                    ParaviewExportIntegrationPointResultsAtNodes<true>>(p,
+                                                                        params);
               });
     this->add("ComputeResultantForceOnBoundary",
               [](NonLinearEvolutionProblemImplementation<true>& p,
@@ -113,6 +121,13 @@ namespace mfem_mgis {
                  const Parameters& params) {
                 return std::make_unique<ParaviewExportResults<false>>(p,
                                                                       params);
+              });
+    this->add("ParaviewExportIntegrationPointResultsAtNodes",
+              [](NonLinearEvolutionProblemImplementation<false>& p,
+                 const Parameters& params) {
+                return std::make_unique<
+                    ParaviewExportIntegrationPointResultsAtNodes<false>>(
+                    p, params);
               });
     this->add("ComputeResultantForceOnBoundary",
               [](NonLinearEvolutionProblemImplementation<false>& p,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,36 @@ if(MFEM_MGIS_HAVE_TFEL)
   add_uniaxial_tensile_test(Plasticity EquivalentPlasticStrain)
   add_uniaxial_tensile_test(Mazars Damage)
   add_uniaxial_tensile_test(SaintVenantKirchhoffElasticity EquivalentStrain)
+
+  add_executable(PartialQuadratureFunctionTest
+    EXCLUDE_FROM_ALL
+    PartialQuadratureFunctionTest.cxx)
+  target_include_directories(PartialQuadratureFunctionTest
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  target_link_libraries(PartialQuadratureFunctionTest
+    PRIVATE MFEMMGIS)
+  add_dependencies(check PartialQuadratureFunctionTest)
+  
+  function(add_partial_quadrature_function_test behaviour internal_state_variable)
+    set(test "PartialQuadratureFunctionTest-${behaviour}")
+    add_test(NAME ${test}
+     COMMAND PartialQuadratureFunctionTest
+     "--mesh" "${CMAKE_CURRENT_SOURCE_DIR}/cube.mesh"
+     "--library" "$<TARGET_FILE:BehaviourTest>"
+     "--behaviour" "${behaviour}"
+     "--reference-file" "${CMAKE_CURRENT_SOURCE_DIR}/references/${behaviour}.ref"
+     "--internal-state-variable" "${internal_state_variable}")
+    if((CMAKE_HOST_WIN32) AND (NOT MSYS))
+      set_property(TEST ${test}
+        PROPERTY DEPENDS BehaviourTest
+        PROPERTY ENVIRONMENT "PATH=$<TARGET_FILE_DIR:MFEMMGIS>\;${MGIS_PATH_STRING}")
+    else((CMAKE_HOST_WIN32) AND (NOT MSYS))
+      set_property(TEST ${test}
+        PROPERTY DEPENDS BehaviourTest)
+    endif((CMAKE_HOST_WIN32) AND (NOT MSYS))
+  endfunction(add_partial_quadrature_function_test)
+  
+  add_partial_quadrature_function_test(OrthotropicElasticity EquivalentStrain)
   
   add_executable(StationaryNonLinearHeatTransferTest
     EXCLUDE_FROM_ALL

--- a/tests/PartialQuadratureFunctionTest.cxx
+++ b/tests/PartialQuadratureFunctionTest.cxx
@@ -1,0 +1,54 @@
+/*!
+ * \file   tests/UniaxialTensileTest.cxx
+ * \brief
+ * \author Thomas Helfer
+ * \date   14/12/2020
+ */
+
+#include <memory>
+#include <cstdlib>
+#include <iostream>
+#ifdef DO_USE_MPI
+#include <mpi.h>
+#endif
+#include "MFEMMGIS/Profiler.hxx"
+#include "MFEMMGIS/Parameters.hxx"
+#include "MFEMMGIS/Material.hxx"
+#include "MFEMMGIS/UniformDirichletBoundaryCondition.hxx"
+#include "MFEMMGIS/NonLinearEvolutionProblem.hxx"
+#include "UnitTestingUtilities.hxx"
+
+int main(int argc, char** argv) {
+#ifdef DO_USE_MPI
+  static constexpr const auto parallel = true;
+#else
+  static constexpr const auto parallel = false;
+#endif
+  constexpr const auto dim = mfem_mgis::size_type{3};
+  auto parameters = mfem_mgis::unit_tests::TestParameters{};
+  // options treatment
+  mfem_mgis::initialize(argc, argv);
+  mfem_mgis::unit_tests::parseCommandLineOptions(parameters, argc, argv);
+  auto success = true;
+  // building the non linear problem
+  mfem_mgis::NonLinearEvolutionProblem problem(
+      {{"MeshFileName", parameters.mesh_file},
+       {"FiniteElementFamily", "H1"},
+       {"FiniteElementOrder", parameters.order},
+       {"UnknownsSize", dim},
+       {"NumberOfUniformRefinements", parallel ? 2 : 0},
+       {"Hypothesis", "Tridimensional"},
+       {"Parallel", parallel}});
+  // materials
+  problem.addBehaviourIntegrator("Mechanics", 1, parameters.library,
+                                 parameters.behaviour);
+  auto& m1 = problem.getMaterial(1);
+  mgis::behaviour::setExternalStateVariable(m1.s0, "Temperature", 293.15);
+  mgis::behaviour::setExternalStateVariable(m1.s1, "Temperature", 293.15);
+  //
+  auto e = getGradient(m1, "Strain");
+  auto s = getThermodynamicForce(m1, "Stress");
+  auto p = getInternalStateVariable(m1, "EquivalentStrain");
+
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/PartialQuadratureFunctionTest.cxx
+++ b/tests/PartialQuadratureFunctionTest.cxx
@@ -49,6 +49,7 @@ int main(int argc, char** argv) {
   auto e = getGradient(m1, "Strain");
   auto s = getThermodynamicForce(m1, "Stress");
   auto p = getInternalStateVariable(m1, "EquivalentStrain");
-
+  success = e.getNumberOfComponents() >= 0 && s.getNumberOfComponents() >= 0 && p.getNumberOfComponents() >= 0;;
+  
   return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/PeriodicTest.cxx
+++ b/tests/PeriodicTest.cxx
@@ -248,6 +248,19 @@ void executeMFEMMGISTest(const TestParameters& p) {
     problem.addPostProcessing(
         "ParaviewExportResults",
         {{"OutputFileName", "PeriodicTestOutput-" + std::to_string(p.tcase)}});
+    std::vector<mfem_mgis::Parameter> materials_out{1,2};
+    problem.addPostProcessing(
+        "ParaviewExportIntegrationPointResultsAtNodes",
+        {{"OutputFileName", "PeriodicTestOutput-Strain-" 
+	      + std::to_string(p.tcase)},
+	    {"Materials", {materials_out}},
+	    {"Results", "Strain"}});
+    problem.addPostProcessing(
+        "ParaviewExportIntegrationPointResultsAtNodes",
+        {{"OutputFileName", "PeriodicTestOutput-Stress-" 
+	      + std::to_string(p.tcase)},
+	    {"Materials", {materials_out}},
+	    {"Results", "Stress"}});
     // solving the problem
     if (!problem.solve(0, 1)) {
       mfem_mgis::abort(EXIT_FAILURE);

--- a/tests/UniaxialTensileTest.cxx
+++ b/tests/UniaxialTensileTest.cxx
@@ -102,12 +102,16 @@ int main(int argc, char** argv) {
         "ParaviewExportResults",
         {{"OutputFileName",
           "UniaxialTensileTestOutput-" + std::string(parameters.behaviour)}});
-    problem.addPostProcessing(
-        "ParaviewExportIntegrationPointResultsAtNodes",
-        {{"OutputFileName", "UniaxialTensileTestIntegrationPointOutput-" +
-                                std::string(parameters.behaviour)},
-         {"Materials", {1}},
-         {"Results", {"Strain"}}});
+    const auto& b = problem.getMaterial(1).b;
+    if((b.btype==mgis::behaviour::Behaviour::STANDARDSTRAINBASEDBEHAVIOUR)&&
+       (b.kinematic==mgis::behaviour::Behaviour::SMALLSTRAINKINEMATIC)){
+      problem.addPostProcessing(
+				"ParaviewExportIntegrationPointResultsAtNodes",
+				{{"OutputFileName", "UniaxialTensileTestIntegrationPointOutput-" +
+				  std::string(parameters.behaviour)},
+				 {"Materials", {1}},
+				 {"Results", {"Strain"}}});
+    }
     // solving the problem in 100 time steps
     auto r = mfem_mgis::unit_tests::solve(problem, parameters, 0, 1, 100);
     // save the results curve

--- a/tests/UniaxialTensileTest.cxx
+++ b/tests/UniaxialTensileTest.cxx
@@ -102,6 +102,12 @@ int main(int argc, char** argv) {
         "ParaviewExportResults",
         {{"OutputFileName",
           "UniaxialTensileTestOutput-" + std::string(parameters.behaviour)}});
+    problem.addPostProcessing(
+        "ParaviewExportIntegrationPointResultsAtNodes",
+        {{"OutputFileName", "UniaxialTensileTestIntegrationPointOutput-" +
+                                std::string(parameters.behaviour)},
+         {"Materials", {1}},
+         {"Results", {"Strain"}}});
     // solving the problem in 100 time steps
     auto r = mfem_mgis::unit_tests::solve(problem, parameters, 0, 1, 100);
     // save the results curve


### PR DESCRIPTION
Replace pull request #29 
Related to issue #25 
The aim is to get new paraview exports. 
From integration points results, we project values on nodes before storing the nodal values in a paraview output.
This feature works in parallel and the API allows for a selection of material identifiers to be exported.
Pleas look at `UniaxialTensileTest.cxx` and `PeriodicTest.cxx` to see how to use this new capability.