### PR TITLE
[BUGFIX] Restore flags for handling Hypre versions prior to 2021

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ include(cmake/modules/mfem-mgis.cmake)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+
 # (must be placed *before* any add_subdirectory, cmake bug ?)
 include(CTest)
 enable_testing()
@@ -87,6 +88,12 @@ else(CMAKE_CONFIGURATION_TYPES)
       ${CMAKE_CTEST_COMMAND} -T test )
    endif(NOT TARGET check)
 endif(CMAKE_CONFIGURATION_TYPES)
+
+# HYPRE version
+include(cmake/modules/hypre.cmake)  
+set(MFEM_HYPRE_VERSION ${HYPRE_VERSION})
+add_compile_definitions(MFEM_HYPRE_VERSION=${MFEM_HYPRE_VERSION})
+
 
 mfem_mgis_buildenv()
 

--- a/cmake/modules/get_hypre_version.cpp
+++ b/cmake/modules/get_hypre_version.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "HYPRE_config.h"
+#include <cstdio>
+
+#ifdef HYPRE_RELEASE_VERSION
+#define HYPRE_VERSION_STRING HYPRE_RELEASE_VERSION
+#elif defined(HYPRE_PACKAGE_VERSION)
+#define HYPRE_VERSION_STRING HYPRE_PACKAGE_VERSION
+#endif
+
+// Macros to expand a macro as a string
+#define STR_EXPAND(s) #s
+#define STR(s) STR_EXPAND(s)
+
+// Convert the HYPRE_RELEASE_VERSION macro (string) to integer.
+// Examples: "2.10.0b" --> 21000, "2.11.2"  --> 21102
+int main()
+{
+#ifdef HYPRE_VERSION_STRING
+   const char *ptr = STR(HYPRE_VERSION_STRING);
+   if (*ptr == '"') { ptr++; }
+   int version = 0;
+   for (int i = 0; i < 3; i++, ptr++)
+   {
+      int pv = 0;
+      for (char d; d = *ptr, '0' <= d && d <= '9'; ptr++)
+      {
+         pv = 10*pv + (d - '0');
+         if (pv >= 100) { return 1; }
+      }
+      version = 100*version + pv;
+   }
+   printf("%i\n", version);
+   return 0;
+#else
+   return 2;
+#endif
+}

--- a/cmake/modules/hypre.cmake
+++ b/cmake/modules/hypre.cmake
@@ -1,0 +1,38 @@
+# Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+# at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+# LICENSE and NOTICE for details. LLNL-CODE-806117.
+#
+# This file is part of the MFEM library. For more information and source code
+# availability visit https://mfem.org.
+#
+# MFEM is free software; you can redistribute it and/or modify it under the
+# terms of the BSD-3 license. We welcome feedback and contributions, see file
+# CONTRIBUTING.md for details.
+
+# Defines the following variables:
+#   - HYPRE_FOUND
+#   - HYPRE_LIBRARIES
+#   - HYPRE_INCLUDE_DIRS
+#   - HYPRE_VERSION
+#   - HYPRE_USING_HIP (internal)
+
+if (HYPRE_FOUND)
+  if (HYPRE_USING_HIP)
+    find_package(rocsparse REQUIRED)
+    find_package(rocrand REQUIRED)
+  endif()
+  return()
+endif()
+
+  try_run(HYPRE_VERSION_RUN_RESULT HYPRE_VERSION_COMPILE_RESULT
+          ${CMAKE_CURRENT_BINARY_DIR}/cmake/modules/
+          ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/get_hypre_version.cpp
+          CMAKE_FLAGS -DINCLUDE_DIRECTORIES:STRING=${HYPRE_INCLUDE_DIRS}
+          RUN_OUTPUT_VARIABLE HYPRE_VERSION_OUTPUT)
+  if ((HYPRE_VERSION_RUN_RESULT EQUAL 0) AND HYPRE_VERSION_OUTPUT)
+    string(STRIP "${HYPRE_VERSION_OUTPUT}" HYPRE_VERSION)
+    set(HYPRE_VERSION ${HYPRE_VERSION} CACHE STRING "HYPRE version." FORCE)
+    message(STATUS "Found HYPRE version ${HYPRE_VERSION}")
+  else()
+    message(FATAL_ERROR "Unable to determine HYPRE version.")
+  endif()

--- a/src/LinearSolverFactory.cxx
+++ b/src/LinearSolverFactory.cxx
@@ -63,7 +63,7 @@ namespace mfem_mgis {
 
   std::unique_ptr<LinearSolverPreconditioner> setHypreILUPreconditioner(
       NonLinearEvolutionProblemImplementation<true>&, const Parameters& opts) {
-#ifndef HYPRE_OLD_VERSION
+#if MFEM_HYPRE_VERSION >= 21900
     using Problem = AbstractNonLinearEvolutionProblem;
     bool verbose = contains(opts, Problem::SolverVerbosityLevel);
     auto ilu = std::make_unique<mfem::HypreILU>();

--- a/src/LinearSolverFactory.cxx
+++ b/src/LinearSolverFactory.cxx
@@ -63,6 +63,7 @@ namespace mfem_mgis {
 
   std::unique_ptr<LinearSolverPreconditioner> setHypreILUPreconditioner(
       NonLinearEvolutionProblemImplementation<true>&, const Parameters& opts) {
+#ifndef HYPRE_OLD_VERSION
     using Problem = AbstractNonLinearEvolutionProblem;
     bool verbose = contains(opts, Problem::SolverVerbosityLevel);
     auto ilu = std::make_unique<mfem::HypreILU>();
@@ -77,6 +78,10 @@ namespace mfem_mgis {
       HYPRE_ILUSetLevelOfFill(*ilu,level);
     }
     return ilu;
+#else /*  HYPRE_OLD_VERSION */
+    MFEM_VERIFY(0, "Support for HypreILU is notavailable with this version of MFEM");
+    return nullptr;
+#endif /* HYPRE_OLD_VERSION */
   }    // end of setHypreILUPreconditioner
 
   std::unique_ptr<LinearSolverPreconditioner> setHypreParaSailsPreconditioner(


### PR DESCRIPTION
To handle old versions of hypre which are still used nowadays.